### PR TITLE
chore: move prettier from devDependencies to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,6 @@
     "eslint": "^8.42.0",
     "eslint-config-prettier": "^8.8.0",
     "eslint-plugin-prettier": "^4.2.1",
-    "prettier": "^2.8.8",
     "rimraf": "^3.0.2"
   },
   "activationEvents": [
@@ -140,6 +139,7 @@
   "dependencies": {
     "@astrojs/language-server": "2.0.17",
     "@astrojs/ts-plugin": "1.0.10",
+    "prettier": "^2.8.8",
     "typescript": "5.0.4"
   }
 }


### PR DESCRIPTION
It seems that there is a conflict between the "devDependencies" of `coc-astro`, which includes Prettier, and the upgraded version 2 of the Astro language server. Due to this conflict, when you install `@yaegassy/coc-astro` using `:CocInstall`, the language server is unable to start properly.

**LOG**:

```
[Info  - 09:35:40.876] Connection to server got closed. Server will restart.
[Error - 09:35:40.878] Server initialization failed.
  Message: Pending response rejected since connection got disposed
  Code: -32097 
[Error - 09:35:40.879] Astro client: couldn't create connection to server.
  Message: Pending response rejected since connection got disposed
  Code: -32097 
node:internal/modules/cjs/loader:1078
  throw err;
  ^

Error: Cannot find module 'prettier'
Require stack:
- /Users/yaegassy/.config/coc/extensions/node_modules/@yaegassy/coc-astro/node_modules/volar-service-prettier/out/index.js
- /Users/yaegassy/.config/coc/extensions/node_modules/@yaegassy/coc-astro/node_modules/@astrojs/language-server/dist/languageServerPlugin.js
- /Users/yaegassy/.config/coc/extensions/node_modules/@yaegassy/coc-astro/node_modules/@astrojs/language-server/dist/nodeServer.js
- /Users/yaegassy/.config/coc/extensions/node_modules/@yaegassy/coc-astro/node_modules/@astrojs/language-server/bin/nodeServer.js
    at Module._resolveFilename (node:internal/modules/cjs/loader:1075:15)
    at Module._load (node:internal/modules/cjs/loader:920:27)
    at Module.require (node:internal/modules/cjs/loader:1141:19)
    at require (node:internal/modules/cjs/helpers:110:18)
    at Object.<anonymous> (/Users/yaegassy/.config/coc/extensions/node_modules/@yaegassy/coc-astro/node_modules/volar-service-prettier/out/index.js:3:20)
    at Module._compile (node:internal/modules/cjs/loader:1254:14)
    at Module._extensions..js (node:internal/modules/cjs/loader:1308:10)
    at Module.load (node:internal/modules/cjs/loader:1117:32)
    at Module._load (node:internal/modules/cjs/loader:958:12)
    at Module.require (node:internal/modules/cjs/loader:1141:19) {
  code: 'MODULE_NOT_FOUND',
  requireStack: [
    '/Users/yaegassy/.config/coc/extensions/node_modules/@yaegassy/coc-astro/node_modules/volar-service-prettier/out/index.js',
    '/Users/yaegassy/.config/coc/extensions/node_modules/@yaegassy/coc-astro/node_modules/@astrojs/language-server/dist/languageServerPlugin.js',
    '/Users/yaegassy/.config/coc/extensions/node_modules/@yaegassy/coc-astro/node_modules/@astrojs/language-server/dist/nodeServer.js',
    '/Users/yaegassy/.config/coc/extensions/node_modules/@yaegassy/coc-astro/node_modules/@astrojs/language-server/bin/nodeServer.js'
  ]
}

Node.js v18.16.0
```

**Related Issue**:

- https://github.com/yaegassy/coc-astro/issues/7