### PR TITLE
feat: add astro.disableResolveCompletionItem setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,9 +50,27 @@ In this case, please execute the command to restart the language server.
 
 - `:CocRestart`
 
+## Dealing with text corruption when determining completion item
+
+coc-astro provides a setting called `astro.disableResolveCompletionItem`. Set this setting to `true` in `coc-settings.json`. The default is `false`.
+
+Please note that if this setting is set to `true`, feature such as "auto-import" upon completion item determination will not work.
+
+**coc-settings.json**:
+
+```json
+{
+  "astro.disableResolveCompletionItem": true
+}
+```
+
+- Related issues in upstream
+  - <https://github.com/withastro/language-tools/issues/664>
+
 ## Configuration options
 
 - `astro.enable`: Enable coc-astro extension, default: `true`
+- `astro.disableResolveCompletionItem`: Disable completionItem/resolve feature, default: `false`
 - `astro.useWorkspaceTsdk`: Use workspace (project) detected tsLibs in astro. if false, use coc-astro's built-in tsLibs, default: `false`
 - `astro.autoCreateQuotes`: Enable/disable auto creation of quotes for HTML attribute assignment, default: `true`
 - `astro.autoClosingTags`: Enable/disable autoClosing of HTML tags, default: `true`

--- a/package.json
+++ b/package.json
@@ -80,6 +80,11 @@
           "default": true,
           "description": "Enable coc-astro extension."
         },
+        "astro.disableResolveCompletionItem": {
+          "type": "boolean",
+          "default": false,
+          "description": "Disable completionItem/resolve feature."
+        },
         "astro.useWorkspaceTsdk": {
           "type": "boolean",
           "default": false,

--- a/src/index.ts
+++ b/src/index.ts
@@ -63,6 +63,15 @@ export async function activate(context: ExtensionContext): Promise<void> {
   const clientOptions: LanguageClientOptions = {
     documentSelector: [{ language: 'astro' }],
     initializationOptions,
+    middleware: {
+      resolveCompletionItem(item, token, next) {
+        // REF: https://github.com/withastro/language-tools/issues/664
+        if (workspace.getConfiguration('astro').get<boolean>('disableResolveCompletionItem')) {
+          return item;
+        }
+        return next(item, token);
+      },
+    },
   };
 
   const client = new LanguageClient('astro', 'Astro', serverOptions, clientOptions);


### PR DESCRIPTION
Description
-------------------------------------------------------

In some cases, text may be corrupted when determining completion item.

https://github.com/yaegassy/coc-astro/assets/188642/7d000b1c-731b-4966-aae3-50e2b83f84e4

---

- Related issues in upstream
  - <https://github.com/withastro/language-tools/issues/664>

coc-astro has added a configuration to solve this problem.

- `astro.disableResolveCompletionItem`: Disable `completionItem/resolve` feature, default: `false`

Please note that if this setting is set to `true`, feature such as "auto-import" upon completion item determination will not work.
